### PR TITLE
ブログの Link タグの修正

### DIFF
--- a/pages/blog/[name].tsx
+++ b/pages/blog/[name].tsx
@@ -178,17 +178,19 @@ const LinkBox = (props: { title: string; url: string; select?: boolean }) => {
   }
   return (
     <Link href={props.url} passHref>
-      <Box
-        py="1"
-        px="3"
-        border={border}
-        color={color}
-        borderColor={`gray.300`}
-        bg={bg}
-        borderRadius="lg"
-      >
-        {props.title}
-      </Box>
+      <a>
+        <Box
+          py="1"
+          px="3"
+          border={border}
+          color={color}
+          borderColor={`gray.300`}
+          bg={bg}
+          borderRadius="lg"
+        >
+          {props.title}
+        </Box>
+      </a>
     </Link>
   );
 };


### PR DESCRIPTION
next/link の Link タグは空のaタグを中に書いてあげないと div タグとしてレンダリングされちゃうので修正。


参考: https://nextjs.org/docs/api-reference/next/link