### PR TITLE
Feature: make link in pages/intern/{year}/{id} as link with <a />

### DIFF
--- a/component/InternItem.tsx
+++ b/component/InternItem.tsx
@@ -1,10 +1,4 @@
-import {
-  Divider,
-  SimpleGrid,
-  GridItem,
-  Text,
-  Box,
-} from "@chakra-ui/layout";
+import { Divider, SimpleGrid, GridItem, Text, Box } from "@chakra-ui/layout";
 import { FC, useMemo } from "react";
 
 export const InternItem: FC = function ({ children }) {

--- a/component/InternItem.tsx
+++ b/component/InternItem.tsx
@@ -1,0 +1,70 @@
+import {
+  Divider,
+  SimpleGrid,
+  GridItem,
+  Text,
+  Box,
+} from "@chakra-ui/layout";
+import { FC, useMemo } from "react";
+
+export const InternItem: FC = function ({ children }) {
+  return (
+    <>
+      <Divider />
+      <SimpleGrid
+        py="4"
+        // columns={{ base: 1, md: 2, lg: 2, sm: 1 }}
+        templateColumns={{ base: "repeat(1, 1fr)", md: "repeat(3, 1fr)" }}
+        spacing={2}
+      >
+        {children}
+      </SimpleGrid>
+    </>
+  );
+};
+
+export const InternItemTitle: FC<{ title: string }> = function ({ title }) {
+  return (
+    <GridItem colSpan={{ base: 1, md: 1 }}>
+      <Text fontSize="18" fontWeight="bold">
+        {title}
+      </Text>
+    </GridItem>
+  );
+};
+
+export const InternItemContent: FC<{ content: string }> = function ({
+  content,
+}) {
+  return (
+    <GridItem colSpan={{ base: 1, md: 2 }} maxW="100vw">
+      <Box>
+        <Text>
+          {content === undefined || content == "" ? "記載なし" : content}
+        </Text>
+      </Box>
+    </GridItem>
+  );
+};
+
+export const InternItemUrl: FC<{ url: string }> = function ({ url: rawUrl }) {
+  const url = useMemo(() => {
+    const trimmed = rawUrl.trim();
+    return trimmed.startsWith("http") ? (
+      <Text color="blue.400">
+        <a href={trimmed} target="_blank" rel="noreferrer">
+          {trimmed}
+        </a>
+      </Text>
+    ) : (
+      rawUrl
+    );
+  }, [rawUrl]);
+  return (
+    <GridItem colSpan={{ base: 1, md: 2 }} maxW="100vw">
+      <Box>
+        <Text>{url == "" ? "記載なし" : url}</Text>
+      </Box>
+    </GridItem>
+  );
+};

--- a/pages/intern/2021/[id].tsx
+++ b/pages/intern/2021/[id].tsx
@@ -1,21 +1,14 @@
-import {
-  Text,
-  Box,
-  Flex,
-  SimpleGrid,
-  GridItem,
-  Grid,
-  Divider,
-} from "@chakra-ui/layout";
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbSeparator,
-} from "@chakra-ui/react";
+import { Text, Box } from "@chakra-ui/layout";
+import { Breadcrumb, BreadcrumbItem } from "@chakra-ui/react";
 import { ChevronRightIcon } from "@chakra-ui/icons";
 import data from "../../../intern2021.json";
 import Link from "next/link";
+import {
+  InternItem as Item,
+  InternItemContent as Content,
+  InternItemTitle as Title,
+  InternItemUrl as Url,
+} from "../../../component/InternItem";
 
 export async function getStaticPaths() {
   let paths = [];
@@ -87,44 +80,42 @@ export default function detailPage({ target }) {
         </Text>
       </Box>
 
-      <Item title="内容" content={target.content} />
-      <Item title="応募期限" content={target.limit} />
-      <Item title="対象" content={target.target} />
-      <Item title="求めるスキル" content={target.skill} />
-      <Item title="給料" content={target.salary} />
-      <Item title="期間" content={target.span} />
-      <Item title="交通費" content={target.transportationexpenses} />
-      <Item title="ホテル" content={target.hotel} />
-      <Item title="応募先" content={target.url} />
+      <Item>
+        <Title title="内容" />
+        <Content content={target.content} />
+      </Item>
+      <Item>
+        <Title title="応募期限" />
+        <Content content={target.limit} />
+      </Item>
+      <Item>
+        <Title title="対象" />
+        <Content content={target.target} />
+      </Item>
+      <Item>
+        <Title title="求めるスキル" />
+        <Content content={target.skill} />
+      </Item>
+      <Item>
+        <Title title="給料" />
+        <Content content={target.salary} />
+      </Item>
+      <Item>
+        <Title title="期間" />
+        <Content content={target.span} />
+      </Item>
+      <Item>
+        <Title title="交通費" />
+        <Content content={target.transportationexpenses} />
+      </Item>
+      <Item>
+        <Title title="ホテル" />
+        <Content content={target.hogel} />
+      </Item>
+      <Item>
+        <Title title="応募先" />
+        <Url url={target.url} />
+      </Item>
     </Box>
   );
 }
-
-const Item = (props: { title: string; content?: string }) => {
-  return (
-    <>
-      <Divider />
-      <SimpleGrid
-        py="4"
-        // columns={{ base: 1, md: 2, lg: 2, sm: 1 }}
-        templateColumns={{ base: "repeat(1, 1fr)", md: "repeat(3, 1fr)" }}
-        spacing={2}
-      >
-        <GridItem colSpan={{ base: 1, md: 1 }}>
-          <Text fontSize="18" fontWeight="bold">
-            {props.title}
-          </Text>
-        </GridItem>
-        <GridItem colSpan={{ base: 1, md: 2 }} maxW="100vw">
-          <Box>
-            <Text>
-          {props.content === undefined || props.content == ""
-            ? "記載なし"
-            : props.content}
-            </Text>
-            </Box>
-        </GridItem>
-      </SimpleGrid>
-    </>
-  );
-};


### PR DESCRIPTION
## Motivation

I fix link in `pages/intern/{year}/{id}` page as valid link with `<a />`

(also, I refactored `<InternItem />` component a bit, if you feel discomfort, please feel free to point out or send `change request`)

FYI: https://www.student-salary.com/intern/2021/6c144930-1756-4213-8a08-0e24973b1248

## Screenshots

|before|after|
|:--:|:--:|
|![Screen Shot 2021-09-12 at 23 29 37](https://user-images.githubusercontent.com/42742053/132991611-bee91013-28ec-4de7-9ef0-fc1730634ab2.png)|![Screen Shot 2021-09-12 at 23 29 43](https://user-images.githubusercontent.com/42742053/132991615-7dfefc5b-440f-46d1-bcd9-470244958538.png)|

