### PR TITLE
ヘッダーロゴのnext/linkにaタグを付与

### DIFF
--- a/component/header.tsx
+++ b/component/header.tsx
@@ -1,13 +1,9 @@
 import {
   Box,
-  Container,
-  Text,
-  Menu,
+  Container, Flex, Menu,
   MenuButton,
   MenuItem,
-  MenuList,
-  Flex,
-  Spacer,
+  MenuList, Spacer, Text
 } from "@chakra-ui/react";
 import Link from "next/link";
 
@@ -17,9 +13,11 @@ export const Header = () => {
       <Container maxW="container.xl">
         <Flex>
           <Link href={`/`} passHref>
+          <a>
             <Text fontSize="xl" fontWeight="bold">
               StudentSalary
             </Text>
+            </a>
           </Link>
           <Spacer />
           <HeaderMenu />


### PR DESCRIPTION
#1 と同じでヘッダーロゴにaタグが書かれていなかった！
